### PR TITLE
Fix css styling of ::before selector of select2 options in RTL

### DIFF
--- a/src/select2totree.css
+++ b/src/select2totree.css
@@ -77,6 +77,7 @@
 }
 .s2-to-tree .select2-dropdown[dir*="rtl"] li.select2-results__option.non-leaf .expand-collapse:before {
 	right: -0.35em;
+	left: unset;
 }
 .s2-to-tree li.select2-results__option.non-leaf.opened .expand-collapse:before {
 	content: "−";


### PR DESCRIPTION
This is styling fix of the following problem:
In RTL mode, the ::before selector becomes full width and appear over the related 'option', So on-click  'option' it expands the sub-items of the 'option' instead of selecting it